### PR TITLE
Don't run vulkan test on vc4-drm + core20

### DIFF
--- a/units/graphics-test-tools.pxu
+++ b/units/graphics-test-tools.pxu
@@ -107,6 +107,7 @@ requires:
   connections.plug in ["graphics-test-tools:graphics-core20", "graphics-test-tools:graphics-core22", "graphics-test-tools:gpu-2404"]
   connections.plug == "graphics-test-tools:opengl"
   connections.plug == "graphics-test-tools:wayland"
+  graphics_card.driver != vc4-drm
 _summary: Run vulkaninfo to verify Vulkan setup on Wayland
 plugin: shell
 user: root

--- a/units/graphics-test-tools.pxu
+++ b/units/graphics-test-tools.pxu
@@ -3,6 +3,7 @@ template-resource: graphics_card
 imports:
   from com.canonical.certification import connections
   from com.canonical.certification import executable
+  from io.mir-server import graphics_card
 requires:
   executable.name == "graphics-test-tools.drm-info"
   connections.plug in ["graphics-test-tools:graphics-core20", "graphics-test-tools:graphics-core22", "graphics-test-tools:gpu-2404"]
@@ -105,9 +106,9 @@ imports:
 requires:
   executable.name == "graphics-test-tools.vulkaninfo"
   connections.plug in ["graphics-test-tools:graphics-core20", "graphics-test-tools:graphics-core22", "graphics-test-tools:gpu-2404"]
+  connections.plug in ["graphics-test-tools:graphics-core22", "graphics-test-tools:gpu-2404"] or graphics_card.driver in ["i915", "iris", "radeonsi", "nvidia"]
   connections.plug == "graphics-test-tools:opengl"
   connections.plug == "graphics-test-tools:wayland"
-  graphics_card.driver != vc4-drm
 _summary: Run vulkaninfo to verify Vulkan setup on Wayland
 plugin: shell
 user: root


### PR DESCRIPTION
I don't think vulkan is supported by vc4-drm (old Broadcom driver). And the test fails with:

```
Cannot create Vulkan instance.
This problem is often caused by a faulty installation of the Vulkan driver or attempting to use a GPU that does not support Vulkan.
/build/vulkan-tools-qBobiK/vulkan-tools-1.2.131.1+dfsg1/vulkaninfo/vulkaninfo.h:371: failed with ERROR_INCOMPATIBLE_DRIVER
```